### PR TITLE
More flexible, not all systems have bash at /bin/bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -ueo pipefail
 #set -x
 


### PR DESCRIPTION
Using /usr/bin/env takes bash from $PATH as opposed to from hardcoded path that may or may not exist.
For example NixOS' path to bash is /run/current-system/sw/bin/bash and install script won't run on it.