### PR TITLE
POP_OS dropdown/popup white background quick fix

### DIFF
--- a/src/gnome-shell/gnome-shell.css
+++ b/src/gnome-shell/gnome-shell.css
@@ -766,6 +766,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-menu {
   min-width: 200px;
   color: rgba(0, 0, 0, 0.75);
+  background: transparent; /*Fixes popup transparency issue on Pop_OS*/
 }
 
 .popup-menu .popup-sub-menu {


### PR DESCRIPTION
Quick fix for a white background issue noticed on dropdown/pop-up menus in the gnome shell. Found on the POP_OS Linux distribution. See here: https://imgur.com/a/VTzU8pZ