### PR TITLE
Fix typo in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,7 @@ if [[ "${#colors[@]}" -eq 0 ]] ; then
 fi
 
 if [[ "${#solids[@]}" -eq 0 ]] ; then
-  colors=("${SOLID_VARIANTS[@]}")
+  solids=("${SOLID_VARIANTS[@]}")
 fi
 
 for color in "${colors[@]}"; do


### PR DESCRIPTION
After updating today, I notice the theme no longer works, and after checking the code, there seems to be a typo in line 192 where it should be `solids=("${SOLID_VARIANTS[@]}")` rather than `colors=("${SOLID_VARIANTS[@]}")`.

Changing that line fix the issue for me